### PR TITLE
Remove role dependency on OUlibraries.centos7.

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -132,5 +132,4 @@ galaxy_info:
   #- packaging
   #- system
   - web
-# dependencies:
-# - OULibraries.centos7
+dependencies: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -132,5 +132,5 @@ galaxy_info:
   #- packaging
   #- system
   - web
-dependencies:
-  - OULibraries.centos7
+# dependencies:
+# - OULibraries.centos7


### PR DESCRIPTION
Commented out Centos 7 role dependency
## Motivation and Context

Having the role listed as a dependency causes it to run whenever the ngrok role is run, which adds unnecessary wait time to ngrok changes.
## How Has This Been Tested?

Successful vagrant up and independent application of the ngrok role. 
